### PR TITLE
Fixed typo in readme for git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Streams library from GitHub.  You can do that by cloning our public repository
 here:
 
 ```
-$ git clone https://aws/amazon-connect-streams
+$ git clone https://github.com/aws/amazon-connect-streams
 ```
 
 Once you download streams, change into the directory and build it:


### PR DESCRIPTION
git clone command had an invalid URL, should be https://*github.com*/aws/amazon-connect-streams