### PR TITLE
requestPermission() callback tweak

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -410,7 +410,7 @@
          this.permission = NotificationPermission.DENIED;
 
       } else if (this.permission !== NotificationPermission.GRANTED) {
-         global.Notification.requestPermission(function(permission) {
+         global.Notification.requestPermission().then(function(permission) {
             self.permission = permission;
             if (permission === NotificationPermission.GRANTED) {
                self._showQueued();


### PR DESCRIPTION
Changing callback to be executed inside the then promise function to get rid of deprecation warning

Gets rid of below deprecation warning:
![screen shot 2017-12-01 at 9 59 42 am](https://user-images.githubusercontent.com/2022994/33491028-a0889ecc-d67e-11e7-80c7-a15978e83139.png)
