### PR TITLE
fix: added eventbus flush and additional resets to .terminate()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -86,7 +86,13 @@
    connect.core.terminate = function() {
       connect.core.client = new connect.NullClient();
       connect.core.masterClient = new connect.NullClient();
-      connect.core.eventBus = new connect.EventBus();
+      var bus = connect.core.getEventBus();
+      if(bus) bus.unsubscribeAll();
+      connect.core.bus = new connect.EventBus();
+      connect.core.agentDataProvider = null;
+      connect.core.upstream = null;
+      connect.core.keepaliveManager = null;
+      connect.agent.initialized = false;
       connect.core.initialized = false;
    };
 


### PR DESCRIPTION
*Issue #, if available:*
Currently calling connect.core.terminate() still retains state and any subsequent .initCCP calls results in the connect.core.eventbus accumulating contact subscriptions.

Steps to reproduce (requires use with connect-rtc-js):
- Call initCCP
- Assign agent hooks
- Assign contact hooks
- Make a Call
- Call connect.core.terminate()
- Observe persistent agent data in connect.core.agentDataProvider
- Call initCCP again
- Assign agent hooks
- Assign contact hooks
- Make a Call

After these steps you will notice the EventBus is holding onto additional old subscriptions and video stream is unable to properly attach itself to video element. 

*Description of changes:*
I have added 'resets' to properties during .terminate() to mimic Connect's state on first load. This provides more predictable behavior and remedies the issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
