### PR TITLE
Add documentation and type definitions for onStateChange handler

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -186,6 +186,17 @@ agent.onRefresh(function(agent) { ... });
 ```
 Subscribe a method to be called whenever new agent data is available.
 
+### `agent.onStateChange()`
+```
+agent.onStateChange(function(agentStateChange) { ... });
+```
+Subscribe a method to be called when the agent's state changes. The
+`agentStateChange` object contains the following properties:
+
+* `agent`: The Agent object.
+* `newState`: The name of the agent's new state.
+* `oldState`: The name of the agent's previous state.
+
 ### `agent.onRoutable()`
 ```
 agent.onRoutable(function(agent) { ... });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,6 +14,15 @@ declare namespace connect {
     type AgentCallback = (agent: Agent) => void;
 
     /**
+     *
+     * A callback to receive agent and state change details
+     *
+     * @param agentStateChange An object containing the current agent object and
+     * state transition information.
+     */
+    type AgentStateChangeCallback = (agentStateChange: AgentStateChange) => void;
+
+    /**
      * Register a callback to receive agent details
      *
      * @param callback A callback that will receive an {Agent} instance
@@ -237,6 +246,12 @@ declare namespace connect {
          */
         onRefresh(callback: AgentCallback): void;
         /**
+         * Subscribe a method to be called when the agent's state changes.
+         *
+         * @param callback A callback to receive updated Agent and state information.
+         */
+        onStateChange(callback: AgentStateChangeCallback): void;
+        /**
          * Subscribe a method to be called when the agent becomes routable, meaning that they can be routed incoming contacts.
          *
          * @param callback A callback to receive updated Agent information.
@@ -350,6 +365,23 @@ declare namespace connect {
          * Sets the agent localmedia to unmute mode.
          */
         unmute(): void;
+    }
+
+    interface AgentStateChange {
+        /*
+         * The Agent object.
+         */
+        agent: Agent;
+
+        /*
+         * The name of the agent's new state.
+         */
+        newState: string;
+
+        /*
+         * The name of the agent's previous state.
+         */
+        oldState: string;
     }
 
     /**
@@ -507,7 +539,7 @@ declare namespace connect {
         /**
          * Get a map from attribute name to value for each attribute associated with the contact.
          */
-        getAttributes(): { [key: string]: string };
+        getAttributes(): { [key: string] : { name: string, value: string } };
         /*
          * Determine whether this contact is a softphone call.
          */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add documentation for `onStateChange` event handler.
- Update type definitions for `onStateChange` event handler.
- Reintroduce fix made in https://github.com/aws/amazon-connect-streams/pull/103

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
