### PR TITLE
Bugfix/dom exception play 81

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
-*Issue #, if available:*
+#81:
 
-*Description of changes:*
+The code change fixes uncaught promise DOMException with the play() function.
+Before user has interacted with the iframe it's not allowed to play sound.
+This fix delegates the autoplay permission via allow attribute to the ccp iframe preventing this error.
 
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,6 @@
-#81:
+*Issue #, if available:*
 
-The code change fixes uncaught promise DOMException with the play() function.
-Before user has interacted with the iframe it's not allowed to play sound.
-This fix delegates the autoplay permission via allow attribute to the ccp iframe preventing this error.
+*Description of changes:*
 
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/src/core.js
+++ b/src/core.js
@@ -363,7 +363,7 @@
       // Create the CCP iframe and append it to the container div.
       var iframe = document.createElement('iframe');
       iframe.src = params.ccpUrl;
-      iframe.allow = "microphone";
+      iframe.allow = "microphone; autoplay";
       iframe.style = "width: 100%; height: 100%";
       containerDiv.appendChild(iframe);
 


### PR DESCRIPTION
#81:

The code change fixes uncaught promise DOMException with the play() function.
Before user has interacted with the iframe it's not allowed to play sound.
This fix delegates the autoplay permission via allow attribute to the ccp iframe preventing this error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
