### PR TITLE
Returning subscription objects from subscribe APIs

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -851,19 +851,20 @@
     * Root Subscription APIs.
     */
    connect.agent = function(f) {
+      var bus = connect.core.getEventBus();
+      var sub = bus.subscribe(connect.AgentEvents.INIT, f);
+
       if (connect.agent.initialized) {
          f(new connect.Agent());
-
-      } else {
-         var bus = connect.core.getEventBus();
-         bus.subscribe(connect.AgentEvents.INIT, f);
       }
+
+      return sub;
    };
    connect.agent.initialized = false;
 
    connect.contact = function(f) {
       var bus = connect.core.getEventBus();
-      bus.subscribe(connect.ContactEvents.INIT, f);
+      return bus.subscribe(connect.ContactEvents.INIT, f);
    };
 
    /**

--- a/src/event.js
+++ b/src/event.js
@@ -142,6 +142,8 @@
       var subList = this.subEventNameMap[eventName] || [];
       subList.push(sub);
       this.subEventNameMap[eventName] = subList;
+
+      return sub;
    };
 
    /**


### PR DESCRIPTION
The documentation mentions being able to unsubscribe from the streams APIs, however I was noticing console errors when doing so. Did some digging and saw that the code wasn't returning the Subscription objects in the APIs. Then noticed an existing issue (#58) for this.


*Issue #, if available:* #58 

*Description of changes:*
Returning subscription objects from the following to allow for clients to clean-up subscriptions appropriately.

1. Root subscription APIs (agent + contact)
2. Event bus subscribe

Returning the subscription object is straight-forward for the event bus and contact APIs. For the agent API, I elected to always subscribe and return, instead of only subscribing if the agent is not initialized. I felt that consistency in the object returned was more important.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
