### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SOURCE_FILES = src/aws-client.js \
 					src/client.js \
 					src/transitions.js \
 					src/api.js \
-					src/lib/amazon-connect-websocket-manager.js,
+					src/lib/amazon-connect-websocket-manager.js \
 					src/core.js \
 					src/ringtone.js \
 					src/softphone.js \


### PR DESCRIPTION
Fixed typo and added escape to end of line to prevent the following make error:
Makefile:19: *** recipe commences before first target.  Stop.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
