### PR TITLE
Add stubbed getAgentData function to fix failing test

### DIFF
--- a/test/unit/core.spec.js
+++ b/test/unit/core.spec.js
@@ -98,14 +98,30 @@ describe('Core', function () {
             sinon.stub(connect.core, "getUpstream").returns({
                 sendUpstream: sinon.stub()
             });
-        });
 
+            connect.core.getAgentDataProvider = sinon.stub().returns({
+                getAgentData: () => {
+                  return {
+                    configuration: {
+                      routingProfile: {
+                        channelConcurrencyMap: {
+                          CHAT: 0,
+                          VOICE: 1
+                        }
+                      }
+                    }
+                  };
+                }
+            });
+        });
+        
         after(function () {
             connect.SoftphoneManager.restore();
             connect.ifMaster.restore();
             connect.Agent.prototype.isSoftphoneEnabled.restore();
             connect.becomeMaster.restore();
             connect.core.getUpstream.restore();
+            connect.core.getAgentDataProvider.resetBehavior();
         });
 
         it("Softphone manager should get initialized for master tab", function () {


### PR DESCRIPTION
*Description of changes:*

Adds a stubbed function for `getAgentData()` which fixes an issue where the `Softphone manager should get initialized for master tab` test spec was failing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
